### PR TITLE
Update instructions to use Heroku's native buildpack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,9 @@ the [MemCachier Root CA](https://www.memcachier.com/MemCachierRootCA.pem).
 
 ## Usage
 
-You must use this buildpack in conjunction with another buildpack that actually
-runs your app. To do so, first configure your app to use the
-[multi-buildpack](https://github.com/ddollar/heroku-buildpack-multi):
+Heroku now has native support for [multiple buildpacks], so simply run:
 
-    $ heroku config:add BUILDPACK_URL=https://github.com/ddollar/heroku-buildpack-multi.git
-
-Next, add a `.buildpacks` file to your app repository. The file should contain
-the Git URL of each buildpack you'd like to use, including this one. For
-example, to run a Python app with TLS support for MemCachier, your
-`.buildpacks` file should look like this:
-
-    $ cat .buildpacks
-    https://github.com/heroku/heroku-buildpack-python.git
-    https://github.com/memcachier/memcachier-tls-buildpack.git
+    $ heroku buildpacks:add https://github.com/memcachier/memcachier-tls-buildpack.git
 
 Finally, configure your app to connect to `localhost:11211` instead of using
 the `MEMCACHIER_SERVERS` environment variable and deploy!
@@ -49,3 +38,4 @@ This library is written and  maintained by MemCachier,
 
 [buildpack]: https://devcenter.heroku.com/articles/buildpacks
 [stunnel]: https://www.stunnel.org/index.html
+[multiple buildpacks]: https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MemCachier TLS Buildpack
 
 A [buildpack] for connecting to MemCachier over TLS from non-TLS supporting
-clients. The builpack installs and sets up [stunnel] on localhost listening
+clients. The buildpack installs and sets up [stunnel] on localhost listening
 on port 11211. It configures stunnel to connect to the MemCachier servers
 specified in your environment variable and to verify certificates as signed by
 the [MemCachier Root CA](https://www.memcachier.com/MemCachierRootCA.pem).
@@ -36,9 +36,9 @@ We are happy to receive bug reports, fixes, documentation enhancements,
 and other improvements.
 
 Please report bugs via the
-[github issue tracker](http://github.com/memcachier/memcachier-tls-buildpack/issues).
+[github issue tracker](https://github.com/memcachier/memcachier-tls-buildpack/issues).
 
-Master [git repository](http://github.com/memcachier/memcachier-tls-buildpack):
+Master [git repository](https://github.com/memcachier/memcachier-tls-buildpack):
 
 * `git clone git://github.com/memcachier/memcachier-tls-buildpack.git`
 


### PR DESCRIPTION
Since the third-party heroku-buildpack-multi is both unmaintained and no longer necessary.