### PR TITLE
README: Update instructions to insert buildpack before others

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ the [MemCachier Root CA](https://www.memcachier.com/MemCachierRootCA.pem).
 
 Heroku now has native support for [multiple buildpacks], so simply run:
 
-    $ heroku buildpacks:add https://github.com/memcachier/memcachier-tls-buildpack.git
+    $ heroku buildpacks:add -i 1 https://github.com/memcachier/memcachier-tls-buildpack.git
 
 Finally, configure your app to connect to `localhost:11211` instead of using
 the `MEMCACHIER_SERVERS` environment variable and deploy!


### PR DESCRIPTION
Previously the buildpack would have been added to the end of the buildpacks list, causing it to be run last, and seen as the "main" buildpack for the app. Now the buildpack is inserted at the start, with the existing buildpacks shifted lower.

See:
https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app#adding-a-buildpack